### PR TITLE
Added support for EffectListSpellEffect

### DIFF
--- a/wizwalker/memory/memory_objects/spell_effect.py
+++ b/wizwalker/memory/memory_objects/spell_effect.py
@@ -148,10 +148,11 @@ class SpellEffect(PropertyClass):
                 "RandomSpellEffect",
                 "RandomPerTargetSpellEffect",
                 "VariableSpellEffect",
+                "EffectListSpellEffect",
             ):
                 raise ValueError(
                     f"This object is a {type_name} not a"
-                    f" Random/RandomPerTarget/Variable SpellEffect."
+                    f" Random/RandomPerTarget/Variable/EffectList SpellEffect."
                 )
 
         effects = []


### PR DESCRIPTION
I changed maybe_effect_list in SpellEffect to allow for the EffectListSpellEffect variant. Works where previously this function would produce inaccurate data, namely in the utility path Helephant spell (although there are others that use this).