### PR TITLE
Fixed Spell.spell_effects to not duplicate effects

### DIFF
--- a/wizwalker/memory/memory_objects/spell.py
+++ b/wizwalker/memory/memory_objects/spell.py
@@ -85,7 +85,6 @@ class Spell(PropertyClass):
         effects = []
         for addr in await self.read_shared_vector(88):
             effect = DynamicSpellEffect(self.hook_handler, addr)
-            effects.append(DynamicSpellEffect(self.hook_handler, addr))
             match await effect.read_type_name():
                 case "HangingConversionSpellEffect":
                     effect = HangingConversionSpellEffect(self.hook_handler, addr)


### PR DESCRIPTION
Last commit for this function introduced an erroneous line that duplicated the addition of spell effects. This PR fixes it.